### PR TITLE
Don't crash while waiting for clients

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -199,10 +199,12 @@ KoaWebSocketServer.prototype.register = function (method, generator, expose) {
  * @param params object
  */
 KoaWebSocketServer.prototype.broadcast = function (method, params) {
-    for (var i in this.server.clients) {
-        this.server.clients[i].method(method, params, function (err) {
-            debug('Could not send message', data, err);
-        });
+    if(this.server && this.server.clients) {
+        for (var i in this.server.clients) {
+            this.server.clients[i].method(method, params, function (err) {
+                debug('Could not send message', data, err);
+            });
+        }
     }
 }
 


### PR DESCRIPTION
While using koa-webpack-dev-server, I noticed that the websocket server would crash if there were no clients.
